### PR TITLE
Add multiplayer session support with lobby system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Fruit Punch is an online multiplayer card game inspired by Halli Galli, built with a Flask (Python) backend and a Next.js 15 / React 19 frontend. Players take turns flipping cards showing fruit (1-5 quantity), and race to hit the bell when exactly 5 of one fruit type are visible across all players' top cards.
+
+## Commands
+
+### Backend
+```bash
+pip install -r requirements.txt    # also need: pip install flask-cors (missing from requirements.txt)
+cd backend && python app.py        # runs Flask dev server on http://127.0.0.1:5000
+```
+
+### Frontend
+```bash
+cd frontend-react-app
+npm install
+npm run dev       # Next.js dev server on http://localhost:3000
+npm run build     # production build
+npm run lint      # runs next lint
+```
+
+No test framework is configured for either frontend or backend.
+
+## Architecture
+
+### Communication Pattern
+- REST API over HTTP with **polling** (not WebSockets)
+- Frontend polls `GET /state` every 1 second via the `useGameState` custom hook
+- All API endpoints are GET requests (no POST/PUT/DELETE)
+- CORS enabled via `flask-cors`
+
+### Backend (`backend/`)
+- **`app.py`** — Flask entry point, defines all API routes, stores game state in module-level global variables (no database, no session isolation)
+- **`utils/card.py`** — `Card` class and `init_cards()` to build the 56-card deck (4 fruits × 14 cards each)
+- **`utils/pile.py`** — `Pile` class that tracks played cards and implements the bell-hit check (sum of each fruit across top cards == 5)
+- **`utils/player.py`** — `Player` class and `init_players()` factory
+- **`utils/gamegen.py`** — Session ID generator (4-digit random codes, WIP)
+
+### Frontend (`frontend-react-app/src/`)
+- Uses Next.js **App Router** with `'use client'` directives (client-side rendering)
+- Path alias: `@/*` maps to `./src/*` (configured in `jsconfig.json`)
+- **`components/Game.js`** — Main game orchestrator; calls `/init/<n>` to start, renders players/cards/buttons
+- **`components/Lobby.js`** — Pre-game lobby for hosting/joining sessions (WIP)
+- **`components/Card.js`** — Renders individual card with fruit image
+- **`components/Players.js`** — Displays player grid with top cards
+- **`components/FlipCardButton.js`** — Calls `GET /flip-card/<player_id>`
+- **`components/BuzzerButton.js`** — Bell button (click handler is currently a stub, not wired to API)
+- **`hooks/useGameState.js`** — Custom hook that polls `/state` every second and returns game state
+- **`css/`** — Component stylesheets; also uses Bootstrap 5.3
+
+### API Endpoints (all GET)
+| Endpoint | Purpose |
+|---|---|
+| `/init/<num_players>` | Initialize/reset game, deal cards |
+| `/state` | Return full game state (polled by frontend) |
+| `/flip-card/<player_id>` | Flip current player's top card |
+| `/hit-bell/<player_id>` | Claim bell hit (5 of one fruit visible) |
+| `/host-game/<playername>` | Create new session, return session_id |
+| `/join/<session_id>/<playername>` | Join existing session |
+
+### Key Constraints
+- All game state lives in Python global variables — only one game instance exists at a time on the server
+- The lobby/session system (`gamegen.py`, `Lobby.js`) is work-in-progress and does not yet provide session isolation
+- Backend and frontend must both be running simultaneously for the game to work

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,93 +1,176 @@
-from typing import List
-
 from flask import Flask, jsonify
-from flask_cors import CORS  # Import CORS
+from flask_cors import CORS
 
-from utils.card import Card, setup_game
+from utils.card import setup_game
+from utils.gamegen import create_session_id
 from utils.pile import Pile
-from utils.player import initialize_players, Player
+from utils.player import Player
 
 app = Flask(__name__)
-CORS(app)  # Enable CORS qfor all routes
+CORS(app)
 
-cards: List[Card] = setup_game()
-players: List[Player] = []
-current_player_index = 0
-pile: Pile = Pile()
+sessions = {}  # Dict[str, dict] — all game state keyed by session_id
 
 print("Everything is ready to go!")
 
 
-def set_next_player_turn():
-    global players, current_player_index
+def get_session(session_id):
+    """Look up a session by ID. Returns (session, None) or (None, error_response)."""
+    session = sessions.get(str(session_id))
+    if session is None:
+        return None, (jsonify({"error": f"Session {session_id} not found"}), 404)
+    return session, None
+
+
+def set_next_player_turn(session):
+    players = session["players"]
+    current_player_index = session["current_player_index"]
+
     players[current_player_index].set_turn(False)
     next_player_index = (current_player_index + 1) % len(players)
-    players[next_player_index].set_turn(True)
 
-    # Update the current player id
-    current_player_index = next_player_index
+    # Skip players with no cards remaining
+    attempts = 0
+    while attempts < len(players):
+        candidate = players[next_player_index]
+        if candidate.get_num_cards_on_hand() > 0 or candidate.top_card is not None:
+            break
+        next_player_index = (next_player_index + 1) % len(players)
+        attempts += 1
+
+    players[next_player_index].set_turn(True)
+    session["current_player_index"] = next_player_index
 
     return next_player_index
 
 
-@app.route("/init/<int:num_players>", methods=["GET"])
-def init_game(num_players):
-    # Logic to initialize the game with the given number of players
-    global players, cards
-    players = initialize_players(num_players=num_players, cards=cards)
-    if players:
-        players[0].set_turn(True)
-
-    print("Game initialized with players: ")
-    print(players)
-    print("========================")
-    return jsonify({"message": f"Game initialized with {num_players} players"}), 200
+def check_game_over(session):
+    """Check if only one player has cards left."""
+    players = session["players"]
+    players_with_cards = [p for p in players if p.get_num_cards_on_hand() > 0 or p.top_card is not None]
+    if len(players_with_cards) == 1:
+        return True, players_with_cards[0]
+    return False, None
 
 
-@app.route("/hit-bell/<int:player_id>", methods=["GET"])
-def hit_bell(player_id):
-    global players, pile
+@app.route("/host-game/<playername>", methods=["GET"])
+def host_game(playername):
+    session_id = str(create_session_id())
+    new_player = Player(name=playername)
 
-    if 0 <= player_id < len(players):
-        all_player_top_cards = [
-            player.get_top_card() for player in players if player.get_top_card()
-        ]
+    sessions[session_id] = {
+        "players": [new_player],
+        "cards": None,
+        "pile": Pile(),
+        "current_player_index": 0,
+        "started": False,
+    }
 
-        if pile.check_bell_hit(all_player_top_cards):
-            winning_player = players[player_id]
-            collected_cards = pile.collect_cards()
-            winning_player.collect_cards(collected_cards)
-
-            return (
-                jsonify(
-                    {
-                        "message": f"Player {player_id} hit the bell and won the round!",
-                        "collected_cards": [str(card) for card in collected_cards],
-                    }
-                ),
-                200,
-            )
-        else:
-            return (
-                jsonify({"message": "Bell hit incorrectly. No cards collected."}),
-                200,
-            )
-    else:
-        return jsonify({"error": "Invalid player ID"}), 400
+    print(f"Session {session_id} created by {playername}")
+    return jsonify({"session_id": session_id, "player_id": 0}), 200
 
 
-@app.route("/flip-card/<int:player_id>", methods=["GET"])
-def flip_card(player_id):
-    global players, pile
+@app.route("/join/<session_id>/<playername>", methods=["GET"])
+def join(session_id, playername):
+    session, error = get_session(session_id)
+    if error:
+        return error
 
-    print(f"Got a request: {player_id}")
+    if session["started"]:
+        return jsonify({"error": "Game already started"}), 400
+
+    new_player = Player(name=playername)
+    session["players"].append(new_player)
+    player_id = len(session["players"]) - 1
+
+    print(f"{playername} joined session {session_id} as player {player_id}")
+    return jsonify({"message": f"Player {playername} has joined the game", "player_id": player_id}), 200
+
+
+@app.route("/start/<session_id>", methods=["GET"])
+def start_game(session_id):
+    session, error = get_session(session_id)
+    if error:
+        return error
+
+    players = session["players"]
+    num_players = len(players)
+
+    if num_players < 2:
+        return jsonify({"error": "Need at least 2 players to start"}), 400
+
+    # Deal cards
+    cards = setup_game()
+    for i, player in enumerate(players):
+        player.pile_of_cards = []
+        player.top_card = None
+        player.is_turn = False
+        player.collect_cards(cards[i::num_players])
+
+    players[0].set_turn(True)
+    session["current_player_index"] = 0
+    session["started"] = True
+
+    print(f"Session {session_id} started with {num_players} players")
+    return jsonify({"message": f"Game started with {num_players} players"}), 200
+
+
+@app.route("/state/<session_id>", methods=["GET"])
+def get_game_state(session_id):
+    session, error = get_session(session_id)
+    if error:
+        return error
+
+    players = session["players"]
+    pile = session["pile"]
+
+    player_states = [
+        {
+            "player_id": i,
+            "name": player.name,
+            "top_card": {
+                "fruit": player.get_top_card().fruit if player.get_top_card() else "",
+                "quantity": player.get_top_card().number if player.get_top_card() else 0,
+            },
+            "num_cards": player.get_num_cards_on_hand(),
+        }
+        for i, player in enumerate(players)
+    ]
+
+    num_cards_in_pile = pile.get_num_cards()
+    game_over, winner = check_game_over(session)
+
+    return (
+        jsonify(
+            {
+                "current_player_id": session["current_player_index"],
+                "players": player_states,
+                "num_cards_in_pile": num_cards_in_pile,
+                "game_over": game_over,
+                "winner": winner.name if winner else None,
+                "started": session["started"],
+            }
+        ),
+        200,
+    )
+
+
+@app.route("/flip-card/<session_id>/<int:player_id>", methods=["GET"])
+def flip_card(session_id, player_id):
+    session, error = get_session(session_id)
+    if error:
+        return error
+
+    players = session["players"]
+    pile = session["pile"]
+
     if 0 <= player_id < len(players):
         player = players[player_id]
         if player.is_turn:
             try:
                 flipped_card = player.flip_card()
                 pile.play_card(flipped_card)
-                next_player_index = set_next_player_turn()
+                next_player_index = set_next_player_turn(session)
                 return (
                     jsonify(
                         {
@@ -107,36 +190,52 @@ def flip_card(player_id):
         return jsonify({"error": "Invalid player ID"}), 400
 
 
-@app.route("/state", methods=["GET"])
-def get_game_state():
-    global players, pile, current_player_index
-    print(players, pile, current_player_index)
-    player_states = [
-        {
-            "player_id": i,
-            "top_card": {
-                "fruit": player.get_top_card().fruit if player.get_top_card() else "",
-                "quantity": (
-                    player.get_top_card().number if player.get_top_card() else 0
+@app.route("/hit-bell/<session_id>/<int:player_id>", methods=["GET"])
+def hit_bell(session_id, player_id):
+    session, error = get_session(session_id)
+    if error:
+        return error
+
+    players = session["players"]
+    pile = session["pile"]
+
+    if 0 <= player_id < len(players):
+        all_player_top_cards = [
+            player.get_top_card() for player in players if player.top_card is not None
+        ]
+
+        if pile.check_bell_hit(all_player_top_cards):
+            winning_player = players[player_id]
+            collected_cards = pile.collect_cards()
+            winning_player.collect_cards(collected_cards)
+
+            for player in players:
+                player.top_card = None
+
+            return (
+                jsonify(
+                    {
+                        "message": f"{winning_player.name} hit the bell and won the round!",
+                        "collected_cards": [str(card) for card in collected_cards],
+                    }
                 ),
-            },
-            "num_cards": player.get_num_cards_on_hand(),
-        }
-        for i, player in enumerate(players)
-    ]
-
-    num_cards_in_pile = pile.get_num_cards()
-
-    return (
-        jsonify(
-            {
-                "current_player_id": current_player_index,
-                "players": player_states,
-                "num_cards_in_pile": num_cards_in_pile,
-            }
-        ),
-        200,
-    )
+                200,
+            )
+        else:
+            offending_player = players[player_id]
+            cards_given = 0
+            for other_player in players:
+                if other_player is not offending_player:
+                    if offending_player.pile_of_cards:
+                        card = offending_player.pile_of_cards.pop()
+                        other_player.collect_cards([card])
+                        cards_given += 1
+            return (
+                jsonify({"message": f"Bell hit incorrectly! {offending_player.name} gave {cards_given} card(s) as penalty."}),
+                200,
+            )
+    else:
+        return jsonify({"error": "Invalid player ID"}), 400
 
 
 @app.route("/", methods=["GET"])

--- a/backend/utils/gamegen.py
+++ b/backend/utils/gamegen.py
@@ -1,0 +1,5 @@
+import random
+
+
+def create_session_id():
+    return random.randint(1000, 9999)

--- a/backend/utils/pile.py
+++ b/backend/utils/pile.py
@@ -9,7 +9,9 @@ class Pile:
         self.played_cards.append(card)
     
     def collect_cards(self):
-        return self.played_cards
+        cards = self.played_cards[:]
+        self.played_cards = []
+        return cards
 
     def check_bell_hit(self, all_player_top_cards):
         fruit_counts = {}
@@ -18,6 +20,4 @@ class Pile:
                 fruit_counts[card.fruit] += card.number
             else:
                 fruit_counts[card.fruit] = card.number
-            if fruit_counts[card.fruit] == 5:
-                return True
-        return False
+        return any(count == 5 for count in fruit_counts.values())

--- a/backend/utils/player.py
+++ b/backend/utils/player.py
@@ -39,11 +39,17 @@ class Player:
         return f"Player(name={self.name}, is_turn={self.is_turn}, pile_size={len(self.pile_of_cards)})"
 
 
-def initialize_players(num_players, cards: List[Card]):
+def initialize_players(num_players, cards: List[Card], existing_players=None):
     """Initialize the players and distributes the given number of cards."""
     players = []
     for i in range(num_players):
-        player = Player(f"Player {i+1}")
+        if existing_players and i < len(existing_players):
+            player = existing_players[i]
+            player.pile_of_cards = []
+            player.top_card = None
+            player.is_turn = False
+        else:
+            player = Player(f"Player {i+1}")
         player.collect_cards(cards[i::num_players])
         players.append(player)
     return players

--- a/frontend-react-app/src/components/BuzzerButton.js
+++ b/frontend-react-app/src/components/BuzzerButton.js
@@ -3,10 +3,16 @@
 
 import React from 'react';
 
-const BuzzerButton = () => {
+const BuzzerButton = ({ playerId, sessionId }) => {
   const handleBuzzerClick = () => {
-    // Add logic to handle buzzer click event
-    console.log('Buzzer button clicked!');
+    fetch(`http://10.0.0.179:5001/hit-bell/${sessionId}/${playerId}`)
+      .then(response => response.json())
+      .then(data => {
+        alert(data.message);
+      })
+      .catch(error => {
+        console.error('Error hitting buzzer:', error);
+      });
   };
 
   return (

--- a/frontend-react-app/src/components/FlipCardButton.js
+++ b/frontend-react-app/src/components/FlipCardButton.js
@@ -3,10 +3,10 @@
 
 import React from 'react';
 
-const FlipCardButton = ({ playerId }) => {
+const FlipCardButton = ({ playerId, sessionId, isMyTurn }) => {
     const handleFlipCard = async () => {
         try {
-          const response = await fetch(`http://127.0.0.1:5000/flip-card/${playerId}`, {
+          const response = await fetch(`http://10.0.0.179:5001/flip-card/${sessionId}/${playerId}`, {
             method: 'GET',
           });
           const data = await response.json();
@@ -21,17 +21,21 @@ const FlipCardButton = ({ playerId }) => {
     };
 
   return (
-    <button onClick={handleFlipCard} style={{
-      padding: '20px',
-      fontSize: '24px',
-      width: '50%',
-      backgroundColor: '#4CAF50',
-      color: '#fff',
-      border: 'none',
-      borderRadius: '5px',
-      cursor: 'pointer',
-    }}>
-      Flip Card
+    <button
+      onClick={handleFlipCard}
+      disabled={!isMyTurn}
+      style={{
+        padding: '20px',
+        fontSize: '24px',
+        width: '50%',
+        backgroundColor: isMyTurn ? '#4CAF50' : '#9E9E9E',
+        color: '#fff',
+        border: 'none',
+        borderRadius: '5px',
+        cursor: isMyTurn ? 'pointer' : 'not-allowed',
+        opacity: isMyTurn ? 1 : 0.7,
+      }}>
+      {isMyTurn ? 'Flip Card' : "Opponent's Turn"}
     </button>
   );
 };

--- a/frontend-react-app/src/components/Game.js
+++ b/frontend-react-app/src/components/Game.js
@@ -1,25 +1,27 @@
 // src/app/page.js
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Card from './Card';
 import Players from './Players';
 import FlipCardButton from './FlipCardButton';
 import BuzzerButton from './BuzzerButton';
 import useGameState from '../hooks/useGameState';
+import Lobby from './Lobby';
 
 const GamePage = () => {
+  const [isGameStarted, setIsGameStarted] = useState(false);
   const [currentPlayerId, setCurrentPlayerId] = useState(0);
-
-  const [players, setPlayers] = useState([
-    { id: 0, name: 'Player 1', hand: { fruit: 'Lime', quantity: 3 } },
-    { id: 1, name: 'Player 2', hand: { fruit: 'Banana', quantity: 4 } },
-  ]);
+  const [players, setPlayers] = useState([]);
+  const [gameOver, setGameOver] = useState(false);
+  const [winner, setWinner] = useState(null);
+  const [myPlayerId, setMyPlayerId] = useState(null);
+  const [sessionId, setSessionId] = useState(null);
 
   const renderGameState = (newGameState) => {
     setPlayers(newGameState.players.map(player => ({
       id: player.player_id,
-      name: `Player ${player.player_id + 1}`,
+      name: player.name,
       hand: {
         fruit: player.top_card.fruit,
         quantity: player.top_card.quantity,
@@ -27,45 +29,72 @@ const GamePage = () => {
       num_cards: player.num_cards,
     })));
     setCurrentPlayerId(newGameState.current_player_id);
+    setGameOver(newGameState.game_over);
+    setWinner(newGameState.winner);
   };
 
-  useGameState(renderGameState);
-
-  useEffect(() => {
-    const initializeGame = async () => {
-      try {
-        const response = await fetch('http://127.0.0.1:5000/init/2', {
-          method: 'GET',
-        });
-        if (!response.ok) {
-          throw new Error('Network response was not ok');
-        }
-        console.log('Game initialized successfully with 2 players');
-      } catch (error) {
-        console.error('Failed to initialize game:', error);
+  const handleStartGame = (sid, pid) => {
+    fetch(`http://10.0.0.179:5001/start/${sid}`)
+    .then(response => {
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
       }
-    };
+      return response.json();
+    })
+    .then(data => {
+      console.log('Game started successfully:', data);
+      setSessionId(sid);
+      setMyPlayerId(pid);
+      setIsGameStarted(true);
+    })
+    .catch(error => {
+      console.error('Failed to start game:', error);
+    });
+  };
 
-    initializeGame();
-  }, []);
+  const joinGame = (sid, pid) => {
+    setSessionId(sid);
+    setMyPlayerId(pid);
+    setIsGameStarted(true);
+  };
+
+  useGameState(renderGameState, isGameStarted, sessionId);
+
+  const isMyTurn = currentPlayerId === myPlayerId;
+
+  if (!isGameStarted) {
+    return <Lobby handleStartGame={handleStartGame} joinGame={joinGame}/>;
+  }
 
   return (
     <div style={{
       display: 'flex',
       flexDirection: 'column',
-      minHeight: '100vh', // Ensures the container takes the full height of the viewport
+      minHeight: '100vh',
     }}>
-      <Players players={players} currentPlayerId={currentPlayerId} />
-      <div style={{
-        padding: '20px',
-        display: 'flex',
-        justifyContent: 'space-between',
-        gap: '20px',
-        borderTop: '1px solid #ccc', // Optional: adds a border to separate the buttons from the grid
-      }}>
-        <FlipCardButton playerId={currentPlayerId} />
-        <BuzzerButton />
-      </div>
+      {gameOver ? (
+        <div style={{textAlign: 'center', padding: '50px'}}>
+          <h1>Game Over!</h1>
+          <h2>{winner} wins!</h2>
+          <button className="btn btn-primary btn-lg" onClick={() => window.location.reload()}>
+            Play Again
+          </button>
+        </div>
+      ) : (
+        <>
+          <Players players={players} currentPlayerId={currentPlayerId} />
+          <div style={{
+            padding: '20px',
+            display: 'flex',
+            justifyContent: 'space-between',
+            gap: '20px',
+            borderTop: '1px solid #ccc',
+          }}>
+            <FlipCardButton playerId={myPlayerId} sessionId={sessionId} isMyTurn={isMyTurn} />
+            <BuzzerButton playerId={myPlayerId} sessionId={sessionId} />
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/frontend-react-app/src/components/Lobby.js
+++ b/frontend-react-app/src/components/Lobby.js
@@ -1,0 +1,144 @@
+// src/components/Lobby.js
+'use client';
+import React, { useState } from 'react';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import '../css/Lobby.css';
+
+
+
+const Lobby = ( {handleStartGame, joinGame} ) => {
+  const [username, setUsername] = useState('');
+  const [gameId, setGameId] = useState('');
+  const [isGameHosted, setIsGameHosted] = useState(false);
+  const [myPlayerId, setMyPlayerId] = useState(null);
+
+
+  const handleHostGame = () => {
+    if (username) {
+      fetch(`http://10.0.0.179:5001/host-game/${username}`, {
+        method: 'GET',
+      })
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        return response.json();
+      })
+      .then(data => {
+        console.log('Game hosted successfully:', data);
+        setIsGameHosted(true);
+        setGameId(data.session_id);
+        setMyPlayerId(data.player_id);
+      })
+      .catch(error => {
+        console.error('Failed to host game:', error);
+      });
+    } else {
+      alert('Please enter a username');
+    }
+  };
+
+  const handleJoinGame = () => {
+    if (username && gameId) {
+      fetch(`http://10.0.0.179:5001/join/${gameId}/${username}`, {
+        method: 'GET',
+      })
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        return response.json();
+      })
+      .then(data => {
+        console.log('Game joined successfully:', data);
+        setMyPlayerId(data.player_id);
+        joinGame(gameId, data.player_id);
+      })
+      .catch(error => {
+        console.error('Failed to join game:', error);
+      });
+    } else {
+      alert('Please enter a username and game ID');
+    }
+  };
+
+  const startGameUI = () => {
+    console.log('startGameUI');
+    return (
+      <div className="modal show" tabIndex="-1" style={{ display: 'block' }}>
+        <div className="modal-dialog">
+          <div className="modal-content">
+            <div className="modal-header">
+              <h5 className="modal-title">You are the host (Session ID: {gameId})</h5>
+              <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div className="modal-body">
+              <p> Share the Session ID with your friends. Once everyone joins, click Start Game! </p>
+            </div>
+            <div className="modal-footer">
+              <button type="button" className="btn btn-secondary" data-bs-dismiss="modal" onClick={() => handleStartGame(gameId, myPlayerId)}>Start Game</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const joinOrHostGameUI = () => {
+    return (
+      <div className="row d-flex justify-content-center align-items-center h-100">
+            <div className="col-8 col-md-8 col-lg-6 col-xl-5">
+              <div className="card bg-dark text-white col-xs-8" style={{ borderRadius: '1rem' }}>
+                <div className="card-body p-5 text-center">
+                  <div className="mb-md-5 mt-md-4 pb-5">
+                    <div data-mdb-input-init className="form-outline form-white mb-4">
+                      <label className="form-label" htmlFor="typeEmailX">User Name</label>
+                      <input type="text"
+                        className="form-control form-control-lg"
+                        value={username}
+                        onChange={(e) => setUsername(e.target.value)}
+                      />
+                    </div>
+
+                    <div data-mdb-input-init className="form-outline form-white mb-4">
+                      <button data-mdb-button-init data-mdb-ripple-init className="btn btn-lg px-5 btn-primary" type="submit" onClick={handleHostGame}>Host</button>
+                    </div>
+
+                  <div data-mdb-input-init className="form-outline form-white mb-4">
+                    (or)
+                  </div>
+
+                  <div data-mdb-input-init className="form-outline form-white mb-4">
+                    <label className="form-label" htmlFor="typeEmailX">Session Code</label>
+                    <input type="text"
+                      className="form-control form-control-lg"
+                      value={gameId}
+                      onChange={(e) => setGameId(e.target.value)}
+                    />
+                  </div>
+
+                  <div data-mdb-input-init className="form-outline form-white mb-4">
+                    <button data-mdb-button-init data-mdb-ripple-init className="btn btn-lg px-5 btn-primary" type="submit" onClick={handleJoinGame}>Join</button>
+                  </div>
+                </div>
+                </div>
+              </div>
+            </div>
+          </div>
+    );
+  };
+
+  return (
+    <section className="vh-100 gradient-custom">
+      <div className="container py-5 h-100">
+        <div style={{ marginTop: '20px', textAlign: 'center' }}>
+          <h1 className="fw-bold mb-2 text-uppercase">Fruit Punch Game</h1>
+        </div>
+
+        {isGameHosted ? startGameUI() : joinOrHostGameUI()}
+      </div>
+    </section>
+  );
+};
+
+export default Lobby;

--- a/frontend-react-app/src/css/Lobby.css
+++ b/frontend-react-app/src/css/Lobby.css
@@ -1,0 +1,10 @@
+.gradient-custom {
+    /* fallback for old browsers */
+    background: #6a11cb;
+
+    /* Chrome 10-25, Safari 5.1-6 */
+    background: -webkit-linear-gradient(to right, rgba(106, 17, 203, 1), rgba(37, 117, 252, 1));
+
+    /* W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
+    background: linear-gradient(to right, rgba(106, 17, 203, 1), rgba(37, 117, 252, 1))
+}

--- a/frontend-react-app/src/hooks/useGameState.js
+++ b/frontend-react-app/src/hooks/useGameState.js
@@ -1,7 +1,7 @@
 // src/hooks/useGameState.js
 import { useState, useEffect } from 'react';
 
-const useGameState = (onGameStateUpdate) => {
+const useGameState = (onGameStateUpdate, isGameStarted, sessionId) => {
   // onGameStateUpdate is a callback function that will be called with the new game state
   // It is responsible for updating the UI with the new game state
 
@@ -10,7 +10,7 @@ const useGameState = (onGameStateUpdate) => {
     console.log('Fetching game state...');
     const fetchGameState = async () => {
       try {
-        const response = await fetch('http://127.0.0.1:5000/state', {
+        const response = await fetch(`http://10.0.0.179:5001/state/${sessionId}`, {
           method: 'GET',
         });
         const data = await response.json();
@@ -25,11 +25,13 @@ const useGameState = (onGameStateUpdate) => {
       }
     };
 
-    fetchGameState(); // Initial fetch
-    const intervalId = setInterval(fetchGameState, 1000); // Fetch every second
+    if (isGameStarted && sessionId) {
+      fetchGameState(); // Initial fetch
+      const intervalId = setInterval(fetchGameState, 1000); // Fetch every second
+      return () => clearInterval(intervalId); // Cleanup on unmount
+    }
 
-    return () => clearInterval(intervalId); // Cleanup on unmount
-  }, []);
+  }, [isGameStarted, sessionId]);
 };
 
 export default useGameState;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+flask-cors


### PR DESCRIPTION
Replace global game state with session-scoped dict so multiple games can run independently. Players host/join via session codes, each tab knows its own player ID, and the flip card button is disabled when it's the opponent's turn. Bell hit messages now show player names.